### PR TITLE
[add] colors to ::backdrop for styling dialog backdrops

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,9 @@ module.exports = plugin.withOptions(function (colors) {
       ':root': {
         ...getColorVars(colors),
       },
+      '::backdrop': {
+        ...getColorVars(colors),
+      },
     });
   }
 }, function (colors) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@doeanderson/tailwindcss-color-vars",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Tailwind CSS plugin to easily manage colors via CSS variables",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`::backdrop` does not inherit from anything so it won't pick up css variables defined on `:root`.